### PR TITLE
refactor of static optimization

### DIFF
--- a/include/s2mStaticOptimization.h
+++ b/include/s2mStaticOptimization.h
@@ -13,109 +13,63 @@
 #include "s2mStaticOptimizationIpoptLinearized.h"
 
 
-    
 class BIORBD_API s2mStaticOptimization
 {
     public:
         s2mStaticOptimization(
-                s2mMusculoSkeletalModel &m,
-                const s2mGenCoord& Q, // states
-                const s2mGenCoord& Qdot, // derived states
-                const s2mGenCoord& Qddot,
-                const s2mVector& Activ,
-                const unsigned int pNormFactor = 2,
-                const int verbose = 0
-                );
-        s2mStaticOptimization(
-                s2mMusculoSkeletalModel &m,
-                const s2mGenCoord& Q, // states
-                const s2mGenCoord& Qdot, // derived states
+                s2mMusculoSkeletalModel& model,
+                const s2mGenCoord& Q,
+                const s2mGenCoord& Qdot,
                 const s2mTau& tauTarget,
-                const s2mVector& Activ,
-                const unsigned int pNormFactor = 2,
-                const int verbose = 0
+                const s2mVector& initialActivationGuess = s2mVector(),
+                unsigned int pNormFactor = 2,
+                bool useResidualTorque = true,
+                int verbose = 0
                 );
         s2mStaticOptimization(
-                s2mMusculoSkeletalModel &m,
-                const s2mGenCoord& Q, // states
-                const s2mGenCoord& Qdot, // derived states
-                const s2mGenCoord& Qddot,
-                const std::vector<s2mMuscleStateActual>& state,
-                const unsigned int pNormFactor = 2,
-                const int verbose = 0
-                );
-        s2mStaticOptimization(
-                s2mMusculoSkeletalModel &m,
-                const s2mGenCoord& Q, // states
-                const s2mGenCoord& Qdot, // derived states
+                s2mMusculoSkeletalModel& model,
+                const s2mGenCoord& Q,
+                const s2mGenCoord& Qdot,
                 const s2mTau& tauTarget,
-                const std::vector<s2mMuscleStateActual>& state,
-                const unsigned int pNormFactor = 2,
-                const int verbose = 0
+                const std::vector<s2mMuscleStateActual>& initialActivationGuess,
+                unsigned int pNormFactor = 2,
+                bool useResidualTorque = true,
+                int verbose = 0
                 );
 
-        //constructors for  a vector of instants to be optimized by ipopt
         s2mStaticOptimization(
-                s2mMusculoSkeletalModel &m,
-                const std::vector<s2mGenCoord>& allQ, // states
-                const std::vector<s2mGenCoord>& allQdot, // derived states
-                const std::vector<s2mGenCoord>& allQddot,
-                const std::vector<s2mVector>& allActiv,
-                const unsigned int pNormFactor = 2,
-                const int verbose = 0
-                );
-        s2mStaticOptimization(
-                s2mMusculoSkeletalModel &m,
+                s2mMusculoSkeletalModel& model,
                 const std::vector<s2mGenCoord>& allQ,
                 const std::vector<s2mGenCoord>& allQdot,
                 const std::vector<s2mTau>& allTauTarget,
-                const std::vector<s2mVector>& allActiv,
-                const unsigned int pNormFactor = 2,
-                const int verbose = 0
+                const s2mVector& initialActivationGuess = s2mVector(),
+                unsigned int pNormFactor = 2,
+                bool useResidualTorque = true,
+                int verbose = 0
                 );
         s2mStaticOptimization(
-                s2mMusculoSkeletalModel &m,
-                const std::vector<s2mGenCoord>& allQ,
-                const std::vector<s2mGenCoord>& allQdot,
-                const std::vector<s2mGenCoord>& allQddot,
-                const std::vector<std::vector<s2mMuscleStateActual>>& allState,
-                const unsigned int pNormFactor = 2,
-                const int verbose = 0
-                );
-        s2mStaticOptimization(
-                s2mMusculoSkeletalModel &m,
+                s2mMusculoSkeletalModel& model,
                 const std::vector<s2mGenCoord>& allQ,
                 const std::vector<s2mGenCoord>& allQdot,
                 const std::vector<s2mTau>& allTauTarget,
-                const std::vector<std::vector<s2mMuscleStateActual>>& allState,
-                const unsigned int pNormFactor = 2,
-                const int verbose = 0
+                const std::vector<s2mMuscleStateActual>& initialActivationGuess,
+                unsigned int pNormFactor = 2,
+                bool useResidualTorque = true,
+                int verbose = 0
                 );
 
-        void run(
-                bool LinearizedState = false
-                );
+        void run(bool useLinearizedState = false);
 
     protected:
-        s2mMusculoSkeletalModel m_model;
-        s2mGenCoord m_Q;
-        s2mGenCoord m_Qdot;
-        s2mGenCoord m_Qddot;
-        s2mTau m_tauTarget;
-        std::vector<s2mMuscleStateActual> m_state;
-        s2mVector m_Activ;
+        s2mMusculoSkeletalModel& m_model;
+        bool m_useResidualTorque;
         std::vector<s2mGenCoord> m_allQ;
         std::vector<s2mGenCoord> m_allQdot;
-        std::vector<s2mGenCoord> m_allQddot;
         std::vector<s2mTau> m_allTauTarget;
-        std::vector<std::vector<s2mMuscleStateActual>> m_allState;
-        std::vector<s2mVector> m_allActiv;
+        s2mVector m_initialActivationGuess;
         unsigned int m_pNormFactor;
         int m_verbose;
-        bool m_useResidual;
-        std::vector<s2mVector> m_finalSolution;
-        unsigned int m_multipleInstant;
-        unsigned int m_configConstructor;
+        std::vector<Ipopt::SmartPtr<Ipopt::TNLP>> m_staticOptimProblem;
 
     private:
 

--- a/include/s2mStaticOptimizationIpopt.h
+++ b/include/s2mStaticOptimizationIpopt.h
@@ -24,8 +24,8 @@ class BIORBD_API s2mStaticOptimizationIpopt : public Ipopt::TNLP
                 const s2mTau                &tauTarget,
                 const s2mVector             &activationInit,
                 bool                        useResidual = true,
-                int                         verbose = 0,
                 unsigned int                pNormFactor = 2,
+                int                         verbose = 0,
                 const double                eps = 1e-10
                 );
 

--- a/include/s2mStaticOptimizationIpoptLinearized.h
+++ b/include/s2mStaticOptimizationIpoptLinearized.h
@@ -17,16 +17,17 @@
 class BIORBD_API s2mStaticOptimizationIpoptLinearized : public s2mStaticOptimizationIpopt
 {
     public:
-        s2mStaticOptimizationIpoptLinearized(s2mMusculoSkeletalModel &model,
-             const s2mGenCoord           &Q,
-             const s2mGenCoord           &Qdot,
-             const s2mTau                &tauTarget,
-             const s2mVector             &activationInit,
-             //bool                        useResidual = true,
-             int                         verbose = 0,
-             unsigned int                p = 2,
-             const double                eps = 1e-15
-                );
+        s2mStaticOptimizationIpoptLinearized(
+                s2mMusculoSkeletalModel &model,
+                const s2mGenCoord           &Q,
+                const s2mGenCoord           &Qdot,
+                const s2mTau                &tauTarget,
+                const s2mVector             &activationInit,
+                bool                        useResidual = true,
+                unsigned int                p = 2,
+                int                         verbose = 0,
+                double                eps = 1e-15
+        );
 
         virtual ~s2mStaticOptimizationIpoptLinearized();
 

--- a/src/s2mStaticOptimization.cpp
+++ b/src/s2mStaticOptimization.cpp
@@ -2,322 +2,137 @@
 #include "../include/s2mStaticOptimization.h"
 
 
-s2mStaticOptimization::s2mStaticOptimization(
-        s2mMusculoSkeletalModel &m,
-        const s2mGenCoord& Q, // states
-        const s2mGenCoord& Qdot, // derived states
-        const s2mGenCoord& Qddot,
-        const s2mVector& Activ,
-        const unsigned int pNormFactor,
-        const int verbose
-        ):
-    m_model(m),
-    m_Q(Q),
-    m_Qdot(Qdot),
-    m_Qddot(Qddot),
-    m_tauTarget(s2mTau(m)),
-    m_Activ(Activ),
-    m_pNormFactor(pNormFactor),
-    m_verbose(verbose),
-    m_finalSolution(std::vector<s2mVector>(m.nbMuscleTotal())),
-    m_multipleInstant(1)
-{
-    std::vector<s2mGenCoord> allQ;
-    allQ.push_back(Q);
-    m_tauTarget.setZero();
-    RigidBodyDynamics::InverseDynamics(m_model, m_Q, m_Qdot, m_Qddot, m_tauTarget);
-    std::cout << "m_Tau\n:" << m_tauTarget << std::endl;
-    for (unsigned int i=0;i<m_model.nbMuscleTotal();i++) {
-        s2mVector x(m_multipleInstant);
-        m_finalSolution[i] = x;}
-}
-
-s2mStaticOptimization::s2mStaticOptimization(
-        s2mMusculoSkeletalModel &m,
+s2mStaticOptimization::s2mStaticOptimization(s2mMusculoSkeletalModel& model,
         const s2mGenCoord &Q,
         const s2mGenCoord &Qdot,
         const s2mTau &tauTarget,
-        const s2mVector &Activ,
-        const unsigned int pNormFactor,
-        const int verbose
+        const s2mVector &initialActivationGuess,
+        unsigned int pNormFactor,
+        bool useResidualTorque,
+        int verbose
         ):
-    m_model(m),
-    m_Q(Q),
-    m_Qdot(Qdot),
-    m_tauTarget(tauTarget),
-    m_Activ(Activ),
+    m_model(model),
+    m_useResidualTorque(useResidualTorque),
     m_pNormFactor(pNormFactor),
-    m_verbose(verbose),
-    m_finalSolution(std::vector<s2mVector>(m.nbMuscleTotal())),
-    m_multipleInstant(1)
+    m_verbose(verbose)
 {
-    for (unsigned int i=0;i<m_model.nbMuscleTotal();i++) {
-        s2mVector x(m_multipleInstant);
-        m_finalSolution[i] = x;}
-}
+    m_allQ.push_back(Q);
+    m_allQdot.push_back(Qdot);
+    m_allTauTarget.push_back(tauTarget);
 
-s2mStaticOptimization::s2mStaticOptimization(
-        s2mMusculoSkeletalModel &m,
-        const s2mGenCoord &Q,
-        const s2mGenCoord &Qdot,
-        const s2mGenCoord &Qddot,
-        const std::vector<s2mMuscleStateActual> &state,
-        const unsigned int pNormFactor,
-        const int verbose
-        ):
-    m_model(m),
-    m_Q(Q),
-    m_Qdot(Qdot),
-    m_Qddot(Qddot),
-    m_tauTarget(s2mTau(m)),
-    m_state(state),
-    m_Activ(s2mVector(m.nbMuscleTotal())),
-    m_pNormFactor(pNormFactor),
-    m_verbose(verbose),
-    m_finalSolution(std::vector<s2mVector>(m.nbMuscleTotal())),
-    m_multipleInstant(1)
-{
-    m_tauTarget.setZero();
-    RigidBodyDynamics::InverseDynamics(m_model, m_Q, m_Qdot, m_Qddot, m_tauTarget);
-    std::cout << "m_Tau\n:" << m_tauTarget << std::endl;
-    m_Activ.setZero();
-    for (unsigned int i = 0; i<m_model.nbMuscleTotal(); i++){
-        m_Activ[i] = m_state[i].activation();
+    if (initialActivationGuess.size() == 0){
+        m_initialActivationGuess = s2mVector(m_model.nbMuscleTotal());
+        for (unsigned int i=0; i<m_model.nbMuscleTotal(); ++i)
+            m_initialActivationGuess[i] = 0.01;
     }
-    for (unsigned int i=0;i<m_model.nbMuscleTotal();i++) {
-        s2mVector x(m_multipleInstant);
-        m_finalSolution[i] = x;}
+    else
+        m_initialActivationGuess = initialActivationGuess;
 }
 
 s2mStaticOptimization::s2mStaticOptimization(
-        s2mMusculoSkeletalModel &m,
+        s2mMusculoSkeletalModel& model,
         const s2mGenCoord &Q,
         const s2mGenCoord &Qdot,
         const s2mTau &tauTarget,
-        const std::vector<s2mMuscleStateActual> &state,
-        const unsigned int pNormFactor,
-        const int verbose
+        const std::vector<s2mMuscleStateActual> &initialActivationGuess,
+        unsigned int pNormFactor,
+        bool useResidualTorque,
+        int verbose
         ):
-    m_model(m),
-    m_Q(Q),
-    m_Qdot(Qdot),
-    m_tauTarget(tauTarget),
-    m_state(state),
-    m_Activ(s2mVector(m.nbMuscleTotal())),
+    m_model(model),
+    m_useResidualTorque(useResidualTorque),
     m_pNormFactor(pNormFactor),
-    m_verbose(verbose),
-    m_finalSolution(std::vector<s2mVector>(m.nbMuscleTotal())),
-    m_multipleInstant(1)
+    m_verbose(verbose)
 {
-    m_Activ.setZero();
-    for (unsigned int i = 0; i<m_model.nbMuscleTotal(); i++){
-        m_Activ[i] = m_state[i].activation();
-    }
-    for (unsigned int i=0;i<m_model.nbMuscleTotal();i++) {
-        s2mVector x(m_multipleInstant);
-        m_finalSolution[i] = x;}
-}
+    m_allQ.push_back(Q);
+    m_allQdot.push_back(Qdot);
+    m_allTauTarget.push_back(tauTarget);
 
-
-//constructors for a vector of instants to be optimized by ipopt
-s2mStaticOptimization::s2mStaticOptimization(
-        s2mMusculoSkeletalModel &m,
-        const std::vector<s2mGenCoord> &allQ,
-        const std::vector<s2mGenCoord> &allQdot,
-        const std::vector<s2mGenCoord> &allQddot,
-        const std::vector<s2mVector> &allActiv,
-        const unsigned int pNormFactor,
-        const int verbose):
-    m_model(m),
-    m_allQ(allQ),
-    m_allQdot(allQdot),
-    m_allQddot(allQddot),
-    m_allActiv(allActiv),
-    m_pNormFactor(pNormFactor),
-    m_verbose(verbose),
-    m_finalSolution(std::vector<s2mVector>(m.nbMuscleTotal())),
-    m_multipleInstant(static_cast<unsigned int>(allQ.size())),
-    m_configConstructor(1)
-
-{
-    unsigned int nbInstant = static_cast<unsigned int>(allQ.size());
-    if (nbInstant != allQdot.size())
-        s2mError::s2mAssert(false, "allQdot is not the same size as allQ, numbers of instant to be optimized must be equal");
-    if (nbInstant != allQddot.size())
-        s2mError::s2mAssert(false, "allQddot is not the same size as allQ, numbers of instant to be optimized must be equal");
-    if (nbInstant != allActiv.size())
-        s2mError::s2mAssert(false, "allActiv is not the same size as allQ, numbers of instant to be optimized must be equal");
-    for (unsigned int i=0;i<m_model.nbMuscleTotal();i++) {
-        s2mVector x(m_multipleInstant);
-        m_finalSolution[i] = x;}
+    m_initialActivationGuess = s2mVector(m_model.nbMuscleTotal());
+    for (unsigned int i = 0; i<m_model.nbMuscleTotal(); i++)
+        m_initialActivationGuess[i] = initialActivationGuess[i].activation();
 }
 
 s2mStaticOptimization::s2mStaticOptimization(
-        s2mMusculoSkeletalModel &m,
+        s2mMusculoSkeletalModel &model,
         const std::vector<s2mGenCoord> &allQ,
         const std::vector<s2mGenCoord> &allQdot,
         const std::vector<s2mTau> &allTauTarget,
-        const std::vector<s2mVector> &allActiv,
-        const unsigned int pNormFactor,
-        const int verbose):
-    m_model(m),
+        const s2mVector &initialActivationGuess,
+        unsigned int pNormFactor,
+        bool useResidualTorque,
+        int verbose) :
+    m_model(model),
+    m_useResidualTorque(useResidualTorque),
     m_allQ(allQ),
     m_allQdot(allQdot),
     m_allTauTarget(allTauTarget),
-    m_allActiv(allActiv),
     m_pNormFactor(pNormFactor),
-    m_verbose(verbose),
-    m_finalSolution(std::vector<s2mVector>(m.nbMuscleTotal())),
-    m_multipleInstant(static_cast<unsigned int>(allQ.size())),
-    m_configConstructor(2)
+    m_verbose(verbose)
 {
-    unsigned int nbInstant = static_cast<unsigned int>(allQ.size());
-    if (nbInstant != allQdot.size())
-        s2mError::s2mAssert(false, "allQdot is not the same size as allQ, numbers of instant to be optimized must be equal");
-    if (nbInstant != allTauTarget.size())
-        s2mError::s2mAssert(false, "allQddot is not the same size as allQ, numbers of instant to be optimized must be equal");
-    if (nbInstant != allActiv.size())
-        s2mError::s2mAssert(false, "allActiv is not the same size as allQ, numbers of instant to be optimized must be equal");
-    for (unsigned int i=0;i<m_model.nbMuscleTotal();i++) {
-        s2mVector x(m_multipleInstant);
-        m_finalSolution[i] = x;}
+    if (initialActivationGuess.size() == 0){
+        m_initialActivationGuess = s2mVector(m_model.nbMuscleTotal());
+        for (unsigned int i=0; i<m_model.nbMuscleTotal(); ++i)
+            m_initialActivationGuess[i] = 0.01;
+    }
+    else
+        m_initialActivationGuess = initialActivationGuess;
 }
 
-s2mStaticOptimization::s2mStaticOptimization(
-        s2mMusculoSkeletalModel &m,
-        const std::vector<s2mGenCoord> &allQ,
-        const std::vector<s2mGenCoord> &allQdot,
-        const std::vector<s2mGenCoord> &allQddot,
-        const std::vector<std::vector<s2mMuscleStateActual> > &allState,
-        const unsigned int pNormFactor,
-        const int verbose):
-    m_model(m),
-    m_allQ(allQ),
-    m_allQdot(allQdot),
-    m_allQddot(allQddot),
-    m_allState(allState),
-    m_pNormFactor(pNormFactor),
-    m_verbose(verbose),
-    m_finalSolution(std::vector<s2mVector>(m.nbMuscleTotal())),
-    m_multipleInstant(static_cast<unsigned int>(allQ.size())),
-    m_configConstructor(3)
-{
-    unsigned int nbInstant = static_cast<unsigned int>(allQ.size());
-    if (nbInstant != allQdot.size())
-        s2mError::s2mAssert(false, "allQdot is not the same size as allQ, numbers of instant to be optimized must be equal");
-    if (nbInstant != allQddot.size())
-        s2mError::s2mAssert(false, "allQddot is not the same size as allQ, numbers of instant to be optimized must be equal");
-    if (nbInstant != allState.size())
-        s2mError::s2mAssert(false, "allActiv is not the same size as allQ, numbers of instant to be optimized must be equal");
-    for (unsigned int i=0;i<m_model.nbMuscleTotal();i++) {
-        s2mVector x(m_multipleInstant);
-        m_finalSolution[i] = x;}
-}
-
-s2mStaticOptimization::s2mStaticOptimization(
-        s2mMusculoSkeletalModel &m,
+s2mStaticOptimization::s2mStaticOptimization(s2mMusculoSkeletalModel& model,
         const std::vector<s2mGenCoord> &allQ,
         const std::vector<s2mGenCoord> &allQdot,
         const std::vector<s2mTau> &allTauTarget,
-        const std::vector<std::vector<s2mMuscleStateActual> > &allState,
-        const unsigned int pNormFactor,
-        const int verbose):
-    m_model(m),
+        const std::vector<s2mMuscleStateActual> &initialActivationGuess,
+        unsigned int pNormFactor,
+        bool useResidualTorque,
+        int verbose):
+    m_model(model),
+    m_useResidualTorque(useResidualTorque),
     m_allQ(allQ),
     m_allQdot(allQdot),
     m_allTauTarget(allTauTarget),
-    m_allState(allState),
     m_pNormFactor(pNormFactor),
-    m_verbose(verbose),
-    m_finalSolution(std::vector<s2mVector>(m.nbMuscleTotal())),
-    m_multipleInstant(static_cast<unsigned int>(allQ.size())),
-    m_configConstructor(4)
+    m_verbose(verbose)
 {
-    unsigned int nbInstant = static_cast<unsigned int>(allQ.size());
-    if (nbInstant != allQdot.size())
-        s2mError::s2mAssert(false, "allQdot is not the same size as allQ, numbers of instant to be optimized must be equal");
-    if (nbInstant != allTauTarget.size())
-        s2mError::s2mAssert(false, "allQddot is not the same size as allQ, numbers of instant to be optimized must be equal");
-    if (nbInstant != allState.size())
-        s2mError::s2mAssert(false, "allActiv is not the same size as allQ, numbers of instant to be optimized must be equal");
-    for (unsigned int i=0;i<m_model.nbMuscleTotal();i++) {
-        s2mVector x(m_multipleInstant);
-        m_finalSolution[i] = x;
-    }
+    m_initialActivationGuess = s2mVector(m_model.nbMuscleTotal());
+    for (unsigned int i = 0; i<m_model.nbMuscleTotal(); i++)
+        m_initialActivationGuess[i] = initialActivationGuess[i].activation();
 }
 
-
-void s2mStaticOptimization::run(
-        bool LinearizedState
-        )
+void s2mStaticOptimization::run(bool LinearizedState)
 {
-   Ipopt::SmartPtr<Ipopt::IpoptApplication> app = IpoptApplicationFactory();
-   app->Options()->SetNumericValue("tol", 1e-7);
-   app->Options()->SetStringValue("mu_strategy", "adaptive");
-   //app->Options()->SetStringValue("output_file", "ipopt.out");
-   app->Options()->SetStringValue("hessian_approximation", "limited-memory");
-   app->Options()->SetStringValue("derivative_test", "first-order");
-   app->Options()->SetIntegerValue("max_iter", 10000);
-   Ipopt::ApplicationReturnStatus status;
-   status = app->Initialize();
-   if( status != Ipopt::Solve_Succeeded )
-       s2mError::s2mAssert(false, "Ipopt initialization failed");
-   if (m_multipleInstant == 1){
-       Ipopt::SmartPtr<Ipopt::TNLP> mynlp;
-       if (LinearizedState)
-           mynlp = new s2mStaticOptimizationIpoptLinearized(m_model, m_Q, m_Qdot, m_tauTarget, m_Activ, m_verbose, m_pNormFactor);
-       else
-           mynlp = new s2mStaticOptimizationIpopt(m_model, m_Q, m_Qdot, m_tauTarget, m_Activ, true, m_verbose, m_pNormFactor);
-       status = app->OptimizeTNLP(mynlp);
-       s2mVector solution(static_cast<Ipopt::SmartPtr<s2mStaticOptimizationIpopt>>(mynlp)->finalSolution());
-       for (unsigned int j=0; j<m_model.nbMuscleTotal(); j++){
-           m_finalSolution[j][0] = solution[j];
-       }
-   }
-   else {
-       for (unsigned int i=0; i<m_multipleInstant; ++i){
-           Ipopt::SmartPtr<Ipopt::TNLP> mynlp;
-           if (m_configConstructor == 1){
-               if (LinearizedState){
-                   mynlp = new s2mStaticOptimizationIpoptLinearized(m_model, m_allQ[i], m_allQdot[i], m_allQddot[i], m_allActiv[i], m_pNormFactor, m_verbose);
-               }
-               else{
-                   mynlp = new s2mStaticOptimizationIpopt(m_model, m_allQ[i], m_allQdot[i], m_allQddot[i], m_allActiv[i], m_pNormFactor, m_verbose);
-               }
-           }
-           else if (m_configConstructor == 2){
-               if (LinearizedState){
-                   mynlp = new s2mStaticOptimizationIpoptLinearized(m_model, m_allQ[i], m_allQdot[i], m_allTauTarget[i], m_allActiv[i], m_pNormFactor, m_verbose);
-               }
-               else{
-                   mynlp = new s2mStaticOptimizationIpopt(m_model, m_allQ[i], m_allQdot[i], m_allTauTarget[i], m_allActiv[i], m_pNormFactor, m_verbose);
-               }
-           }
-           else if (m_configConstructor == 3){
-               if (LinearizedState){
-                   //mynlp = new s2mStaticOptimizationIpoptLinearized(m_model, m_allQ[i], m_allQdot[i], m_allQddot[i], m_allState[i], m_pNormFactor, m_verbose);
-               }
-               else{
+    // Setup the Ipopt problem
+    Ipopt::SmartPtr<Ipopt::IpoptApplication> app = IpoptApplicationFactory();
+    app->Options()->SetNumericValue("tol", 1e-7);
+    app->Options()->SetStringValue("mu_strategy", "adaptive");
+    //app->Options()->SetStringValue("output_file", "ipopt.out");
+    app->Options()->SetStringValue("hessian_approximation", "limited-memory");
+    app->Options()->SetStringValue("derivative_test", "first-order");
+    app->Options()->SetIntegerValue("max_iter", 10000);
 
-                   //mynlp = new s2mStaticOptimizationIpopt(m_model, m_allQ[i], m_allQdot[i], m_allQddot[i], m_allState[i], m_pNormFactor, m_verbose);
-               }
-           }
-           else if (m_configConstructor == 4){
-               if (LinearizedState){
-                   //mynlp = new s2mStaticOptimizationIpoptLinearized(m_model, m_allQ[i], m_allQdot[i], m_allTauTarget[i], m_allState[i], m_pNormFactor, m_verbose);
-               }
-               else{
-                   //mynlp = new s2mStaticOptimizationIpopt(m_model, m_allQ[i], m_allQdot[i], m_allTauTarget[i], m_allState.operator[](i), m_pNormFactor, m_verbose);
-               }
-           }
-           // Ask Ipopt to solve the problem
-           status = app->OptimizeTNLP(mynlp);
-           s2mVector solution(static_cast<Ipopt::SmartPtr<s2mStaticOptimizationIpopt>>(mynlp)->finalSolution());
-           for (unsigned int j=0; j<m_model.nbMuscleTotal(); j++){
-               m_finalSolution[j][i] = solution[j];
-           }
+    Ipopt::ApplicationReturnStatus status;
+    status = app->Initialize();
+    s2mError::s2mAssert(status == Ipopt::Solve_Succeeded, "Ipopt initialization failed");
 
-        }
+    for (unsigned int i=0; i<m_allQ.size(); ++i){
+        if (LinearizedState)
+            m_staticOptimProblem.push_back(
+                        new s2mStaticOptimizationIpoptLinearized(
+                            m_model, m_allQ[i], m_allQdot[i], m_allTauTarget[i], m_initialActivationGuess,
+                            m_useResidualTorque, m_pNormFactor, m_verbose
+                            )
+                        );
+        else
+            m_staticOptimProblem.push_back(
+                        new s2mStaticOptimizationIpopt(
+                            m_model, m_allQ[i], m_allQdot[i], m_allTauTarget[i], m_initialActivationGuess,
+                            m_useResidualTorque, m_pNormFactor, m_verbose
+                            )
+                        );
+
+        // Take the solution of the previous optimization as the solution for the next optimization
+        m_initialActivationGuess = static_cast<Ipopt::SmartPtr<s2mStaticOptimizationIpopt>>(*m_staticOptimProblem.end())->finalSolution();
     }
 }
 

--- a/src/s2mStaticOptimizationIpopt.cpp
+++ b/src/s2mStaticOptimizationIpopt.cpp
@@ -8,8 +8,8 @@ s2mStaticOptimizationIpopt::s2mStaticOptimizationIpopt(
         const s2mTau &tauTarget,
         const s2mVector &activationInit,
         bool useResidual,
-        int verbose,
         unsigned int pNormFactor,
+        int verbose,
         const double eps
         ):
     m_model(model),

--- a/src/s2mStaticOptimizationIpoptLinearized.cpp
+++ b/src/s2mStaticOptimizationIpoptLinearized.cpp
@@ -2,17 +2,18 @@
 #include "../include/s2mStaticOptimizationIpoptLinearized.h"
 
 
-s2mStaticOptimizationIpoptLinearized::s2mStaticOptimizationIpoptLinearized(s2mMusculoSkeletalModel &model,
-           const s2mGenCoord &Q,
-           const s2mGenCoord &Qdot,
-           const s2mTau &tauTarget,
-           const s2mVector &activationInit,
-           //bool useResidual,
-           int verbose,
-           unsigned int p,
-           const double eps
+s2mStaticOptimizationIpoptLinearized::s2mStaticOptimizationIpoptLinearized(
+        s2mMusculoSkeletalModel &model,
+        const s2mGenCoord &Q,
+        const s2mGenCoord &Qdot,
+        const s2mTau &tauTarget,
+        const s2mVector &activationInit,
+        bool useResidual,
+        unsigned int p,
+        int verbose,
+        double eps
         ) :
-    s2mStaticOptimizationIpopt(model, Q, Qdot, tauTarget, activationInit, false, verbose, p, eps),
+    s2mStaticOptimizationIpopt(model, Q, Qdot, tauTarget, activationInit, useResidual, verbose, p, eps),
     m_jacobian(s2mMatrix(m_nDof, m_nMus))
 {
     prepareJacobian();


### PR DESCRIPTION
I removed qddot as entry points since we may decide to actually target qddot and it would not be the same cost function.

Removed bunch of redundant members of s2mStaticOptimization and compressed them into the vectored ones.

Removed the storage of final solution, since storing the actual TNLP stores more information. An interface to get the final results is still to be written though. 

Reinserted useResidualTorque which had been removed for some reason?

If no initial guess is provided, a default one is sent. If one initial guess is provided for the multiple time optimization, this one is used for the first frame then the previous solution is used as the next first guess